### PR TITLE
Remove unnecessary sub image loop.

### DIFF
--- a/src/main/java/tdl/anonymize/image/ImageMasker.java
+++ b/src/main/java/tdl/anonymize/image/ImageMasker.java
@@ -2,23 +2,15 @@ package tdl.anonymize.image;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.List;
 import org.bytedeco.javacpp.DoublePointer;
 import static org.bytedeco.javacpp.opencv_core.CV_32FC1;
 import static org.bytedeco.javacpp.opencv_core.CV_8UC1;
-import org.bytedeco.javacpp.opencv_core.CvRect;
-import org.bytedeco.javacpp.opencv_core.IplImage;
 import org.bytedeco.javacpp.opencv_core.Mat;
-import static org.bytedeco.javacpp.opencv_core.NORM_MINMAX;
 import org.bytedeco.javacpp.opencv_core.Point;
 import org.bytedeco.javacpp.opencv_core.Rect;
 import org.bytedeco.javacpp.opencv_core.Scalar;
 import org.bytedeco.javacpp.opencv_core.Size;
-import static org.bytedeco.javacpp.opencv_core.cvCopy;
-import static org.bytedeco.javacpp.opencv_core.cvResetImageROI;
-import static org.bytedeco.javacpp.opencv_core.cvSetImageROI;
 import static org.bytedeco.javacpp.opencv_core.minMaxLoc;
-import static org.bytedeco.javacpp.opencv_core.normalize;
 import static org.bytedeco.javacpp.opencv_highgui.destroyAllWindows;
 import static org.bytedeco.javacpp.opencv_highgui.imshow;
 import static org.bytedeco.javacpp.opencv_highgui.waitKey;
@@ -26,10 +18,8 @@ import static org.bytedeco.javacpp.opencv_imgcodecs.imread;
 import static org.bytedeco.javacpp.opencv_imgcodecs.imwrite;
 import org.bytedeco.javacpp.opencv_imgproc;
 import static org.bytedeco.javacpp.opencv_imgproc.COLOR_BGR2GRAY;
-import static org.bytedeco.javacpp.opencv_imgproc.CV_FILLED;
 import static org.bytedeco.javacpp.opencv_imgproc.THRESH_TOZERO;
 import static org.bytedeco.javacpp.opencv_imgproc.TM_CCOEFF_NORMED;
-import static org.bytedeco.javacpp.opencv_imgproc.TM_CCORR_NORMED;
 import static org.bytedeco.javacpp.opencv_imgproc.cvtColor;
 import static org.bytedeco.javacpp.opencv_imgproc.matchTemplate;
 import static org.bytedeco.javacpp.opencv_imgproc.rectangle;
@@ -60,68 +50,52 @@ public class ImageMasker implements AutoCloseable {
         }
     }
 
-    public Rect findSubImagePosition(Path subImagePath) throws ImageMaskerException {
-        Mat subImage = imread(subImagePath.toString());
-        if (subImage.empty()) {
-            throw new ImageMaskerException("Cannot open image " + subImagePath.getFileName());
-        }
-        return findSubImagePositionInMainImage(image, subImage);
-    }
-
-    public static Rect findSubImagePositionInMainImage(Mat mainImage, Mat subImage) throws ImageMaskerException {
-        try (Mat mainImageGrey = new Mat(mainImage.size(), CV_8UC1);
-                Mat subImageGrey = new Mat(subImage.size(), CV_8UC1);) {
-
-            cvtColor(mainImage, mainImageGrey, COLOR_BGR2GRAY);
-            cvtColor(subImage, subImageGrey, COLOR_BGR2GRAY);
-            Size size = new Size(mainImageGrey.cols() - subImageGrey.cols() + 1, mainImageGrey.rows() - subImageGrey.rows() + 1);
-            try (Mat result = new Mat(size, CV_32FC1)) {
-                matchTemplate(mainImageGrey, subImageGrey, result, TM_CCOEFF_NORMED);
-                threshold(result, result, 0.1, 1, THRESH_TOZERO);
-                //normalize(result, result, 0, 1, NORM_MINMAX, -1, new Mat());
-                try (
-                        DoublePointer minVal = new DoublePointer(1);
-                        DoublePointer maxVal = new DoublePointer(1);
-                        Point min = new Point();
-                        Point max = new Point();) {
-
-                    minMaxLoc(result, minVal, maxVal, min, max, null);
-                    double val = maxVal.get();
-                    //System.out.println("Val: " + minVal.get() + " " + maxVal.get());
-                    if (val < THRESHOLD) {
-                        throw new ImageMaskerException("Cannot find sub image");
-                    }
-
-                    return new Rect(max.x(), max.y(), subImageGrey.cols(), subImageGrey.rows());
-                }
-            }
-        }
-    }
-
     public int getCount() {
         return counter;
     }
 
-    private static void removeRegionFromImage(Mat image, Rect rect) {
-        int kernelWidth = (int) Math.round(rect.size().width() / 2);
-        int kernelHeight = (int) Math.round(rect.size().height() / 2);
-        try (Mat region = new Mat(image, rect);
-                Size kernelSize = new Size(kernelWidth, kernelHeight);) {
-            opencv_imgproc.blur(region, region, kernelSize);
+    public void removeAllOccurences(Path subImagePath) throws ImageMaskerException {
+        try (
+                Mat subImage = imread(subImagePath.toString());
+                Mat searchImage = new Mat(image);
+                Mat mainImageGrey = new Mat(searchImage.size(), CV_8UC1);
+                Mat subImageGrey = new Mat(subImage.size(), CV_8UC1)) {
+
+            cvtColor(searchImage, mainImageGrey, COLOR_BGR2GRAY);
+            cvtColor(subImage, subImageGrey, COLOR_BGR2GRAY);
+            Size size = new Size(mainImageGrey.cols() - subImageGrey.cols() + 1, mainImageGrey.rows() - subImageGrey.rows() + 1);
+
+            try (Mat result = new Mat(size, CV_32FC1)) {
+                matchTemplate(mainImageGrey, subImageGrey, result, TM_CCOEFF_NORMED);
+                threshold(result, result, 0.1, 1, THRESH_TOZERO);
+
+                removeAllMatchTemplateResult(result, subImage, searchImage);
+            }
         }
     }
 
-    public void findSubImageAndRemoveAllOccurences(Path subImagePath) throws ImageMaskerException {
+    private void removeAllMatchTemplateResult(Mat result, Mat subImage, Mat searchImage) {
         try (
-                Mat subImage = imread(subImagePath.toString());
-                Mat searchImage = new Mat(image);) {
+                DoublePointer minVal = new DoublePointer(1);
+                DoublePointer maxVal = new DoublePointer(1);
+                Point min = new Point();
+                Point max = new Point()) {
+
             while (true) {
-                try (Rect rect = findSubImagePositionInMainImage(searchImage, subImage);) {
-                    removeRegionFromImage(searchImage, rect);
-                    counter += 1;
-                } catch (ImageMaskerException e) {
+                minMaxLoc(result, minVal, maxVal, min, max, null);
+                double val = maxVal.get();
+                if (val < THRESHOLD) {
                     break;
                 }
+                Rect rect = new Rect(max.x(), max.y(), subImage.cols(), subImage.rows());
+
+                int kernelWidth = (int) Math.round(rect.size().width() / 2);
+                int kernelHeight = (int) Math.round(rect.size().height() / 2);
+                try (Mat region = new Mat(searchImage, rect);
+                        Size kernelSize = new Size(kernelWidth, kernelHeight)) {
+                    opencv_imgproc.blur(region, region, kernelSize);
+                }
+                rectangle(result, rect, new Scalar(0, 0, 0, 0));
             }
         }
     }

--- a/src/main/java/tdl/anonymize/image/ImageMasker.java
+++ b/src/main/java/tdl/anonymize/image/ImageMasker.java
@@ -89,14 +89,18 @@ public class ImageMasker implements AutoCloseable {
                 }
                 Rect rect = new Rect(max.x(), max.y(), subImage.cols(), subImage.rows());
 
-                int kernelWidth = (int) Math.round(rect.size().width() / 2);
-                int kernelHeight = (int) Math.round(rect.size().height() / 2);
-                try (Mat region = new Mat(searchImage, rect);
-                        Size kernelSize = new Size(kernelWidth, kernelHeight)) {
-                    opencv_imgproc.blur(region, region, kernelSize);
-                }
+                blurImage(searchImage, rect);
                 rectangle(result, rect, new Scalar(0, 0, 0, 0));
             }
+        }
+    }
+
+    private static void blurImage(Mat searchImage, Rect rect) {
+        int kernelWidth = (int) Math.round(rect.size().width() / 2);
+        int kernelHeight = (int) Math.round(rect.size().height() / 2);
+        try (Mat region = new Mat(searchImage, rect);
+                Size kernelSize = new Size(kernelWidth, kernelHeight)) {
+            opencv_imgproc.blur(region, region, kernelSize);
         }
     }
 

--- a/src/main/java/tdl/anonymize/video/VideoMasker.java
+++ b/src/main/java/tdl/anonymize/video/VideoMasker.java
@@ -49,7 +49,7 @@ public class VideoMasker {
                     ImageMasker masker = new ImageMasker(image);
                     subImagePaths.stream().forEach((subImage) -> {
                         try {
-                            masker.findSubImageAndRemoveAllOccurences(subImage);
+                            masker.removeAllOccurences(subImage);
                             counter += masker.getCount();
                         } catch (ImageMaskerException ex) {
                             //Do nothing

--- a/src/test/java/tdl/anonymize/image/ImageMaskerTest.java
+++ b/src/test/java/tdl/anonymize/image/ImageMaskerTest.java
@@ -17,16 +17,7 @@ public class ImageMaskerTest {
         Path mainImagePath = Paths.get("./src/test/resources/images/barcode-image.png");
         Path subImagePath = Paths.get("./src/test/resources/images/qrcode-subimage-1.png");
         ImageMasker matcher = new ImageMasker(mainImagePath);
-        matcher.findSubImageAndRemoveAllOccurences(subImagePath);
-        //matcher.showImage();
-    }
-
-    @Test
-    public void findSubImagePositionShouldThrowExceptionIfImageNotFound() throws ImageMaskerException {
-        expectedException.expect(ImageMaskerException.class);
-        Path mainImagePath = Paths.get("./src/test/resources/images/main-image-2.jpg");
-        Path subImagePath = Paths.get("./src/test/resources/images/subimage-1-larger.jpg");
-        ImageMasker matcher = new ImageMasker(mainImagePath);
-        matcher.findSubImagePosition(subImagePath);
+        matcher.removeAllOccurences(subImagePath);
+        matcher.showImage();
     }
 }

--- a/src/test/java/tdl/anonymize/image/ImageMaskerTest.java
+++ b/src/test/java/tdl/anonymize/image/ImageMaskerTest.java
@@ -18,6 +18,6 @@ public class ImageMaskerTest {
         Path subImagePath = Paths.get("./src/test/resources/images/qrcode-subimage-1.png");
         ImageMasker matcher = new ImageMasker(mainImagePath);
         matcher.removeAllOccurences(subImagePath);
-        matcher.showImage();
+        //matcher.showImage();
     }
 }


### PR DESCRIPTION
This removes unnecessary `matchTemplate` calls since the result can be used multiple time to match multiple occurrence.

This increases the speed by two times.